### PR TITLE
Manage IBS TH1-Plus models

### DIFF
--- a/InkbirdBtTHSensorAccessory.js
+++ b/InkbirdBtTHSensorAccessory.js
@@ -521,9 +521,9 @@ class cInkbirdBtTHSensorAccessory
 
          if (self.bExternalSensor && self.strModel == 'IBS-TH1-Plus') {
             // CRC check is not available when external probe is used, on IBS-TH1-Plus model
+            self.fAltTemperature = self.cRawStatus.readIntLE(5, 2) / 100;
             self.Log(ELOGLEVEL.DEBUG, `CRC cannot be checked for ${self.strModel} model when external probe is connected`);
             self.Log(ELOGLEVEL.DEBUG, `CRC check skipped, internal sensor temperature ${self.fAltTemperature}°C, external probe temperature ${self.fTemperature}°C, relative humidity ${self.fHumidity}%`);
-            self.fAltTemperature = self.cRawStatus.readIntLE(5, 2) / 100;
          } else {
             self.iCRC = CRC16_0x18005(self.cRawStatus, 0, 4, true, true, 0xFFFF, 0x0);
             if ((self.dSensorCfg != 0) && (self.iCRC != self.cRawStatus.readUIntLE(5, 2)))

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ A homebridge-plugin for the Inkbird bluetooth temperature- and humidity-sensors.
 
 ### Features:
 - Temperature (with Eve history)
-- Humidity (with Eve histor)
+- Humidity (with Eve history)
 - Battery level
 - Supported sensors:
    - IBS-TH1
+   - IBS-TH1-Plus (with external probe)
 
 ## Installation:
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -11,7 +11,7 @@
          },
          "model": {
             "type": "string",
-            "enum": [ "IBS-TH1", "not in list - try it anyway" ],
+            "enum": [ "IBS-TH1", "IBS-TH1-Plus", "not in list - try it anyway" ],
             "title": "Model number (i.e. IBS-TH1, leave empty if not sure)",
             "required": true
          },


### PR DESCRIPTION
This PR intends to fix the #9 issues

- Manage the internal sensor when the external probe is connected by introducing a new Temperature service
- Bypass CRC check for now, when external probe is connected

If you have any advice regarding CRC checks, I will be happy to help on this part too @SteidlD 